### PR TITLE
Feedback

### DIFF
--- a/feedback/topdown-promille-def.R
+++ b/feedback/topdown-promille-def.R
@@ -1,0 +1,105 @@
+## hier aus didaktischen Gründen teilweise englische und deutsche Kommentare gemischt.
+## sie sollten englische Kommentare schreiben (in diesem Kurs & wann immer sie
+## vorhaben anderen Ihren Code zugänglich zu machen.)
+
+# computes approximate BAC (in per mille) at the end of the party (drinking_time[2])
+#
+# method:
+# https://web.archive.org/web/20150123143123/http://promille-rechner.org/erlaeuterung-der-promille-berechnung/
+# massn: 1l@6%; hoibe: 0.5l@6%; wein: 0.2l@11%; schnaps: 0.04l@40%
+#
+# inputs:
+#   age in years
+#   height in cm
+#   weight in kg
+#   drinking_time: sorted POSIXct vector giving start and end of the party
+#   drinks: list or vector with names "massn", "hoibe", "wein", "schnaps"
+#     counting the number consumed of each type of drink
+#  output:
+#    approximate BAC in per mille
+tell_me_how_drunk <- function(age, sex = c("male", "female"), height, weight,
+                              drinking_time, drinks) {
+  # inputs homogen machen:
+  drinks <- unlist(drinks)
+  sex <- tolower(sex)
+  # inputs checken:
+  checkmate::assert_number(age,
+                           lower = 10, upper = 110)
+  sex <- match.arg(sex)
+  checkmate::assert_number(height,
+                           lower = 100, upper = 230)
+  checkmate::assert_number(weight,
+                           lower = 40, upper = 300)
+  checkmate::assert_subset(names(drinks),
+                           choices = c("massn", "hoibe", "wein", "schnaps"),
+                           empty.ok = FALSE)
+  checkmate::assert_numeric(drinks,
+                            lower = 0, any.missing = FALSE, min.len = 1)
+  checkmate::assert_posixct(drinking_time,
+                            any.missing = FALSE, sorted = TRUE, len = 2)
+
+  # isTRUE weil drinks["schnaps"] NA ist wenn kein "schnaps"-Eintrag da ist.
+  illegal <- (age < 16 & sum(drinks) > 0) |
+             (age < 18 & isTRUE(drinks["schnaps"] > 0))
+  if (illegal) {
+    warning("\u2639 ...illegal!  \u2639")
+  }
+
+  alcohol_drunk <- get_alcohol(drinks)
+  bodywater <- get_bodywater(sex, age, height, weight)
+  max_permille <- get_permille(alcohol_drunk, bodywater)
+  sober_up(max_permille, drinking_time)
+}
+
+# compute consumed alcohol in g
+# massn, hoibe: 6%; wein: .2l@11%; schnaps: 4cl@40%
+get_alcohol <- function(drinks) {
+  # in ml
+  volume <- c(
+    "massn" = 1000,
+    "hoibe" = 500,
+    "wein" = 200,
+    "schnaps" = 40
+  )
+  # in volume-%
+  alcohol_concentration <- c(
+    "massn" = 0.06,
+    "hoibe" = 0.06,
+    "wein" = 0.11,
+    "schnaps" = 0.4
+  )
+  alcohol_density <- 0.8
+
+  # die indizierung mit names(drinks) erzeugt vektoren von volumen
+  # und alkoholgehalt die zu den einträgen in drinks passen
+  # (richtige reihenfolge & laenge):
+  sum(drinks * volume[names(drinks)] *
+        alcohol_concentration[names(drinks)] * alcohol_density)
+}
+
+# compute amount of water in a human body
+# coefficients from web-site promillerechner.org linked above
+get_bodywater <- function(sex = c("male", "female"), age, height, weight) {
+  coefficients <- switch(sex,
+                         "male"   = c(2.447, -0.09516, 0.1074, 0.3362),
+                         "female" = c(0.203, -0.07, 0.1069, 0.2466))
+ t(coefficients) %*% c(1, age, height, weight)
+}
+
+# compute max BAC (assumed: at drinking_time[1]...)
+get_permille <- function(alcohol_drunk, bodywater) {
+  alcohol_density <- 0.8
+  blood_density <- 1.055
+  permille <- alcohol_density * alcohol_drunk / (blood_density * bodywater)
+  permille
+}
+
+# compute BAC at drinking_time[2]
+sober_up <- function(permille, drinking_time) {
+  partylength <- difftime(drinking_time[2], drinking_time[1], units = "hours")
+  sober_per_hour <- 0.15
+  # abbau beginnt erst nach einer stunde:
+  depletion_duration <- max(0, partylength - 1)
+  # abbau kann nicht zu negativen promille führen:
+  max(0, permille - depletion_duration * sober_per_hour)
+}

--- a/feedback/topdown-promille-sol.Rmd
+++ b/feedback/topdown-promille-sol.Rmd
@@ -1,0 +1,12 @@
+```{r, child = "topdown-promille-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+Zum Beispiel so:
+```{r, def_promillerechner, code = readLines("topdown-promille-def.R"), echo=TRUE}
+```
+
+Die Fehlermeldungen könnte man hier sicher noch etwas informativer und allgemeinverständlicher machen indem man statt `checkmate::assert_XY` jeweils `if(<argument ungeeignet>) stop("<allgemeinverständliche Fehlermeldung>")` benutzt.  


### PR DESCRIPTION
@asmiknalmpatian 

Ok für den ersten versuch -- Kapselung bitte wesentlich (!) stringenter durchziehen und failing tests ernst nehmen und korrigieren. (und/oder damit ich weiß dass sie das eh geprüft &  gesehen haben entsprechend im code kommentieren falls sie es bei abgabe nicht hinbekommen haben....)


---------------------------------------------

Details:

- https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L19-L21
https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L58
hier überall besser `assert_number` -- `assert_int` ist überspezifisch (warum unbedingt ganze zahl?), `assert_numeric` für vektoren und nicht skalare.

- https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L23
https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L26
codeorganisation: zusammenhängendes besser direkt hintereinander, also l. 26 direkt nach l. 19.  
außerdem einfacher die `assert_posixct` voll auszunutzen, hat ein `sorted`-Argument - vgl a.  Musterlösung

- https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L34
gute idee: inputs homogen machen
leider hier noch nicht wie gewünscht implementiert, das kann so zb hiermit nicht umgehen (s.a. failing tests)
```r
>  tell_me_how_drunk(
+       age = 38,
+       sex = "M",
+       height = 190,
+       weight = 134,
+       drinking_time = as.POSIXct(c("2016-10-03 18:00:00", "2016-10-03 22:00:00")),
+       drinks = list(list("hoibe" = 1), "schnaps" = 2)
+     )
 Error in tell_me_how_drunk(age = 38, sex = "M", height = 190, weight = 134,  : 
  Assertion on 'names(drinks)' failed: Must have names, but element 1 is empty. 
```

- https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L36-L40
hätte man hier einkapseln müssen, ist ein logisch klar abgegrenzter teilschritt der berechnung

- https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L42-L49
hätte man hier einkapseln müssen, sind zwei logisch klar abgegrenzte teilschritte der berechnung

- https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L42
https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L46
codeorganisation: zusammenhängendes wo möglich besser direkt hintereinander, also variablen möglichst direkt dort definieren wo sie zum ersten mal gebraucht werden (hier nicht schlimm, effektv 1 Codezeile dazwischen ist ja egal, aber vom Prinzip her...)

- https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L46-L49
styleguide: keine großbuchstaben

- https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L48 
BUG/FALSCHE IMPLEMENTATION 
viel zu kurz gesprungen hier.  s.a. failing tests:
```r
> test_file("topdown-promille-tests.R")

══ Testing topdown-promille-tests.R ════════════════════════════════════════════════════════════════════════════════════════
[ FAIL 5 | WARN 0 | SKIP 0 | PASS 5 ]

── Failure (topdown-promille-tests.R:26:3): basic implementation is correct ────────────────────────────────────────────────
tell_me_how_drunk(...) not equivalent to 0.687.
1/1 mismatches
[1] 0.0873 - 0.687 == -0.6

── Failure (topdown-promille-tests.R:36:3): basic implementation is correct ────────────────────────────────────────────────
tell_me_how_drunk(...) not equivalent to 0.
1/1 mismatches
[1] -0.167 - 0 == -0.167
```
 vgl Musterlösung


- https://github.com/fort-w2021/promille-ex-asmiknalmpatian/blob/34606439e421731d77df71e1b9726afd11f81ac9/topdown-promille-sol.R#L57
vgl Musterlösung für alternative Lösung dieser funktion.  
ansonsten: riecht nach *conditional complexity* (flavor: viele if blöcke von denen immer nur einer zutreffen kann) -- besser lesbar, kürzer und weniger redundant also mit 2 switch statements:
```r
portion <- 
  switch(type,
    hoibe = 500,
    massn = 1000,
    ...)
volume_percentage <- 
  switch(type,
    hoibe = 0.06,
    massn = 0.06,
    ...)
```

